### PR TITLE
Set both navigationBar appearance to standard

### DIFF
--- a/ThemeKit/Classes/Themes/ThemeManager.swift
+++ b/ThemeKit/Classes/Themes/ThemeManager.swift
@@ -62,13 +62,8 @@ public class Theme {
         standardAppearance.titleTextAttributes = [.foregroundColor: UIColor.themeOz]
         standardAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.themeOz]
 
-        let scrollEdgeAppearance = UINavigationBarAppearance()
-        scrollEdgeAppearance.configureWithTransparentBackground()
-        scrollEdgeAppearance.titleTextAttributes = [.foregroundColor: UIColor.themeOz]
-        scrollEdgeAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.themeOz]
-
         UINavigationBar.appearance().standardAppearance = standardAppearance
-        UINavigationBar.appearance().scrollEdgeAppearance = scrollEdgeAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = standardAppearance
     }
 
 }


### PR DESCRIPTION
To avoid translucent navigationBar when first scrollView in top position.